### PR TITLE
Add adapters from I/O primitives to netd.Backend

### DIFF
--- a/backio/backio.go
+++ b/backio/backio.go
@@ -1,0 +1,2 @@
+// Package backio provides adapters from I/O primitives to netd.Backend.
+package backio

--- a/backio/echo.go
+++ b/backio/echo.go
@@ -1,0 +1,21 @@
+package backio
+
+import (
+	"io"
+	"net"
+
+	"github.com/Invizory/netd"
+)
+
+// Echo creates a backend that copies input to output.
+//
+// Any errors during copy are silently ignored.
+func Echo() netd.Backend {
+	return echo{}
+}
+
+func (echo) Handle(conn net.Conn) {
+	io.Copy(conn, conn)
+}
+
+type echo struct{}

--- a/backio/motd.go
+++ b/backio/motd.go
@@ -1,0 +1,23 @@
+package backio
+
+import (
+	"io"
+	"net"
+
+	"github.com/Invizory/netd"
+)
+
+// Motd creates a backend that copies from the specified publisher to output.
+//
+// Any errors during copy are silently ignored.
+func Motd(publisher io.WriterTo) netd.Backend {
+	return motd{publisher}
+}
+
+func (m motd) Handle(conn net.Conn) {
+	m.WriteTo(conn)
+}
+
+type motd struct {
+	io.WriterTo
+}

--- a/backio/pipe.go
+++ b/backio/pipe.go
@@ -1,0 +1,23 @@
+package backio
+
+import (
+	"io"
+	"net"
+
+	"github.com/Invizory/netd"
+)
+
+// Pipe creates a backend that copies from input to the specified writer.
+//
+// Any errors during copy are silently ignored.
+func Pipe(writer io.Writer) netd.Backend {
+	return pipe{writer}
+}
+
+func (p pipe) Handle(conn net.Conn) {
+	io.Copy(p, conn)
+}
+
+type pipe struct {
+	io.Writer
+}


### PR DESCRIPTION
`Echo`, `Motd` and `Pipe`.

Closes #13.